### PR TITLE
Fix stock order dependent optimization

### DIFF
--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -1063,6 +1063,15 @@ fn compare_cut_instances_for_first_fit(left: &CutInstance, right: &CutInstance) 
         .then_with(|| left.instance.cmp(&right.instance))
 }
 
+fn compare_stock_instances_for_first_fit(left: &StockInstance, right: &StockInstance) -> Ordering {
+    right
+        .width
+        .cmp(&left.width)
+        .then_with(|| right.length.cmp(&left.length))
+        .then_with(|| left.stock_id.0.cmp(&right.stock_id.0))
+        .then_with(|| left.instance.cmp(&right.instance))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct BaselineGuillotineHeuristic {
     rect_choice: GuillotineRectChoice,
@@ -2428,6 +2437,10 @@ fn expand_project(project: &Project) -> Result<ProblemInstance, OptimizeError> {
             "project contains cut pieces but no finite stock instances".to_string(),
         ));
     }
+
+    // Stock input order is UI/import detail, not problem semantics. Canonicalize it before
+    // first-fit candidate construction so a project file's row order cannot decide feasibility.
+    stock.sort_by(compare_stock_instances_for_first_fit);
 
     Ok(ProblemInstance {
         stock,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -324,22 +324,40 @@ impl UiTexts {
         }
     }
 
-    fn optimize_error_message(self, error: OptimizeError) -> String {
+    fn optimize_error_message(self, error: OptimizeError, effort: OptimizerEffort) -> String {
         match error {
             OptimizeError::EmptyInput => match self.language {
                 UiLanguage::English => "No optimizable input".to_string(),
                 UiLanguage::German => "Keine optimierbaren Eingaben".to_string(),
             },
-            OptimizeError::NoSolution => match self.language {
-                UiLanguage::English => "No solution found for the current input".to_string(),
-                UiLanguage::German => {
-                    "Keine Lösung für die aktuellen Eingaben gefunden".to_string()
-                }
-            },
+            OptimizeError::NoSolution => self.no_solution_message(effort),
             OptimizeError::InvalidProject(message) => match self.language {
                 UiLanguage::English => format!("Invalid project: {message}"),
                 UiLanguage::German => format!("Ungültiges Projekt: {message}"),
             },
+        }
+    }
+
+    fn no_solution_message(self, effort: OptimizerEffort) -> String {
+        match (self.language, effort) {
+            (UiLanguage::English, OptimizerEffort::Fast) => {
+                "No solution found with Fast effort. Try Balanced or Thorough before assuming the project cannot be cut.".to_string()
+            }
+            (UiLanguage::English, OptimizerEffort::Balanced) => {
+                "No solution found with Balanced effort. Try Thorough before assuming the project cannot be cut.".to_string()
+            }
+            (UiLanguage::English, OptimizerEffort::Thorough) => {
+                "No solution found for the current input with Thorough effort.".to_string()
+            }
+            (UiLanguage::German, OptimizerEffort::Fast) => {
+                "Mit Optimierungsstufe Schnell wurde keine Lösung gefunden. Versuche Ausgewogen oder Gründlich, bevor du annimmst, dass das Projekt nicht zuschneidbar ist.".to_string()
+            }
+            (UiLanguage::German, OptimizerEffort::Balanced) => {
+                "Mit Optimierungsstufe Ausgewogen wurde keine Lösung gefunden. Versuche Gründlich, bevor du annimmst, dass das Projekt nicht zuschneidbar ist.".to_string()
+            }
+            (UiLanguage::German, OptimizerEffort::Thorough) => {
+                "Mit Optimierungsstufe Gründlich wurde keine Lösung für die aktuellen Eingaben gefunden.".to_string()
+            }
         }
     }
 
@@ -2045,7 +2063,7 @@ fn optimize_current_project(state: &mut FreecutAppState) {
         }
         Err(error) => {
             state.solution = None;
-            state.error_message = Some(texts.optimize_error_message(error));
+            state.error_message = Some(texts.optimize_error_message(error, state.optimizer_effort));
         }
     }
 }
@@ -2961,7 +2979,29 @@ mod tests {
         assert!(state.solution.is_none());
         assert_eq!(
             state.error_message,
-            Some("No solution found for the current input".to_string())
+            Some("No solution found with Fast effort. Try Balanced or Thorough before assuming the project cannot be cut.".to_string())
+        );
+    }
+
+    #[test]
+    fn optimize_action_guides_user_to_stronger_effort_when_balanced_finds_no_solution() {
+        let mut state = FreecutAppState {
+            optimizer_effort: OptimizerEffort::Balanced,
+            ..FreecutAppState::default()
+        };
+        add_default_stock_piece(&mut state);
+        add_default_cut_piece(&mut state);
+        state.project.stock_pieces[0].width = 50;
+        state.project.stock_pieces[0].length = 50;
+        state.project.cut_pieces[0].width = 100;
+        state.project.cut_pieces[0].length = 100;
+
+        optimize_current_project(&mut state);
+
+        assert!(state.solution.is_none());
+        assert_eq!(
+            state.error_message,
+            Some("No solution found with Balanced effort. Try Thorough before assuming the project cannot be cut.".to_string())
         );
     }
 
@@ -2983,7 +3023,7 @@ mod tests {
         assert!(state.solution.is_none());
         assert_eq!(
             state.error_message,
-            Some("Keine Lösung für die aktuellen Eingaben gefunden".to_string())
+            Some("Mit Optimierungsstufe Schnell wurde keine Lösung gefunden. Versuche Ausgewogen oder Gründlich, bevor du annimmst, dass das Projekt nicht zuschneidbar ist.".to_string())
         );
     }
 

--- a/tests/optimizer_regressions.rs
+++ b/tests/optimizer_regressions.rs
@@ -150,6 +150,37 @@ fn thorough_guillotine_places_q71_side_strip_case() {
 }
 
 #[test]
+fn guillotine_thorough_is_independent_of_stock_input_order_for_issue_35() {
+    let width_descending_stock = issue_35_project(vec![
+        stock(101, 1500, 4000, 1),
+        stock(102, 1500, 3500, 1),
+        stock(103, 1250, 5000, 2),
+    ]);
+    let reported_failing_stock_order = issue_35_project(vec![
+        stock(101, 1500, 3500, 1),
+        stock(102, 1250, 5000, 2),
+        stock(103, 1500, 4000, 1),
+    ]);
+
+    for project in [width_descending_stock, reported_failing_stock_order] {
+        let solution = BaselineOptimizer
+            .optimize_with_config(&project, OptimizerConfig::new(OptimizerEffort::Thorough))
+            .expect("issue #35 stock ordering should not decide whether a solution exists");
+
+        assert_eq!(solution.sheets.len(), 4);
+        assert_eq!(
+            solution
+                .sheets
+                .iter()
+                .map(|sheet| sheet.placed_pieces.len())
+                .sum::<usize>(),
+            21
+        );
+        assert_solution_within_bounds_and_non_overlapping(&solution);
+    }
+}
+
+#[test]
 fn nested_places_small_non_guillotine_advantage_case() {
     let nested = nested_project(
         10,
@@ -365,6 +396,45 @@ fn rotation_disabled_regression_project(layout: LayoutKind, disabled_cut_id: u64
             kerf_width: 2,
             layout,
         },
+    }
+}
+
+fn issue_35_project(stock_pieces: Vec<StockPiece>) -> Project {
+    Project {
+        name: "issue-35-stock-order".to_string(),
+        stock_pieces,
+        cut_pieces: vec![
+            cut(1, 551, 2210, 3, true),
+            cut(2, 500, 993, 2, true),
+            cut(3, 700, 1003, 2, true),
+            cut(4, 750, 2026, 1, true),
+            cut(5, 500, 863, 2, true),
+            cut(6, 700, 942, 2, true),
+            cut(7, 551, 2089, 1, true),
+            cut(8, 751, 1662, 1, true),
+            cut(9, 751, 1781, 1, true),
+            cut(10, 551, 1321, 1, true),
+            cut(11, 551, 1262, 1, true),
+            cut(12, 551, 2147, 1, true),
+            cut(13, 750, 1901, 1, true),
+            cut(14, 750, 2026, 1, true),
+            cut(15, 550, 1884, 1, true),
+        ],
+        settings: CutSettings {
+            unit: Unit::Millimeter,
+            kerf_width: 0,
+            layout: LayoutKind::Guillotine,
+        },
+    }
+}
+
+fn stock(id: u64, width: u32, length: u32, quantity: u32) -> StockPiece {
+    StockPiece {
+        id: PieceId(id),
+        width,
+        length,
+        quantity: Some(quantity),
+        pattern: PatternDirection::None,
     }
 }
 


### PR DESCRIPTION
## Summary

- Canonicalize expanded stock instances before first-fit candidate construction
- Add a regression test for the #35 project where one stock row order failed and another solved
- Keep stock row order as UI/import detail instead of optimizer semantics
- Clarify no-solution messages by effort level so users know when to try a stronger search

Fixes #35

## Testing

- `nix develop . -c cargo fmt --check`
- `nix develop . -c cargo test --all`
- `nix develop . -c cargo clippy -- -D warnings`
